### PR TITLE
Create VOTable.vor per Issue #7 "No .vor record for inclusion of VOTable standard in RofR"

### DIFF
--- a/VOTable.vor
+++ b/VOTable.vor
@@ -7,14 +7,14 @@
 	xmlns:vstd="http://www.ivoa.net/xml/StandardsRegExt/v1.0" 
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 	xmlns:ri="http://www.ivoa.net/xml/RegistryInterface/v1.0"
-	xmlns:vot="http://www.ivoa.net/xml/VOTable/VOTable-1.4"
+	xmlns:vot="http://www.ivoa.net/xml/VOTable/v1.3"
 	xsi:schemaLocation="http://www.ivoa.net/xml/VOResource/v1.0
 		http://www.ivoa.net/xml/VOResource/v1.0
 	http://www.ivoa.net/xml/StandardsRegExt/v1.0
 		http://www.ivoa.net/xml/StandardsRegExt/v1.0
 	http://www.ivoa.net/xml/VOResource/v1.0
 		http://www.ivoa.net/xml/VOResource/v1.0
-		http://www.ivoa.net/xml/VOTable/VOTable-1.4">
+		http://www.ivoa.net/xml/VOTable/v1.3">
 
   <title>VO Table</title>
   <identifier>ivo://ivoa.net/std/VOTable</identifier>
@@ -80,8 +80,8 @@ This document describes the structures making up the VOTable standard. The main 
 
   <endorsedVersion status="rec">1.4</endorsedVersion>
 
-	<schema namespace="http://www.ivoa.net/xml/VOTable/VOTable-1.4">
-		<location>http://www.ivoa.net/xml/VOTable/VOTable-1.4</location>
+	<schema namespace="http://www.ivoa.net/xml/VOTable/v1.3">
+		<location>http://www.ivoa.net/xml/VOTable/v1.3</location>
 		<description>VOTable is meant to serialize tabular documents in the context of Virtual Observatory applications. This schema corresponds to the VOTable document available from http://www.ivoa.net/Documents/latest/VOT.html</description>
 	</schema>
 

--- a/VOTable.vor
+++ b/VOTable.vor
@@ -62,6 +62,10 @@
     </creator>
 
     <date role="update">2019-10-21</date>
+	<date role="update">2013-09-20</date>
+	<date role="update">2009-11-30</date>
+	<date role="creation">2004-08-11</date>
+	
     <version>1.4</version>
     <contact>
       <name>Applications WG</name>

--- a/VOTable.vor
+++ b/VOTable.vor
@@ -14,6 +14,7 @@
 		http://www.ivoa.net/xml/StandardsRegExt/v1.0
 	http://www.ivoa.net/xml/VOResource/v1.0
 		http://www.ivoa.net/xml/VOResource/v1.0
+		http://www.ivoa.net/xml/VOTable/v1.3
 		http://www.ivoa.net/xml/VOTable/v1.3">
 
   <title>VO Table Format Definition</title>

--- a/VOTable.vor
+++ b/VOTable.vor
@@ -1,7 +1,7 @@
 <ri:Resource 
 	xsi:type="vstd:Standard" 
-	created="2016-10-21T09:01:00Z"
-	updated="2016-10-21T09:01:00Z"
+	created="2020-05-11T00:00:00Z"
+	updated="2020-05-11T00:00:00Z"
 	status="active"
 	xmlns:vr="http://www.ivoa.net/xml/VOResource/v1.0" 
 	xmlns:vstd="http://www.ivoa.net/xml/StandardsRegExt/v1.0" 
@@ -16,7 +16,7 @@
 		http://www.ivoa.net/xml/VOResource/v1.0
 		http://www.ivoa.net/xml/VOTable/v1.3">
 
-  <title>VO Table</title>
+  <title>VO Table Format Definition</title>
   <identifier>ivo://ivoa.net/std/VOTable</identifier>
   <curation>
     <publisher>IVOA</publisher>

--- a/VOTable.vor
+++ b/VOTable.vor
@@ -1,0 +1,88 @@
+<ri:Resource 
+	xsi:type="vstd:Standard" 
+	created="2016-10-21T09:01:00Z"
+	updated="2016-10-21T09:01:00Z"
+	status="active"
+	xmlns:vr="http://www.ivoa.net/xml/VOResource/v1.0" 
+	xmlns:vstd="http://www.ivoa.net/xml/StandardsRegExt/v1.0" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xmlns:ri="http://www.ivoa.net/xml/RegistryInterface/v1.0"
+	xmlns:vot="http://www.ivoa.net/xml/VOTable/VOTable-1.4"
+	xsi:schemaLocation="http://www.ivoa.net/xml/VOResource/v1.0
+		http://www.ivoa.net/xml/VOResource/v1.0
+	http://www.ivoa.net/xml/StandardsRegExt/v1.0
+		http://www.ivoa.net/xml/StandardsRegExt/v1.0
+	http://www.ivoa.net/xml/VOResource/v1.0
+		http://www.ivoa.net/xml/VOResource/v1.0
+		http://www.ivoa.net/xml/VOTable/VOTable-1.4">
+
+  <title>VO Table</title>
+  <identifier>ivo://ivoa.net/std/VOTable</identifier>
+  <curation>
+    <publisher>IVOA</publisher>
+
+    <creator>
+      <name>Francois Ochsenbein</name>
+    </creator>
+    <creator>
+      <name>Roy Williams</name>
+    </creator>
+    <creator>
+      <name>Clive Davenhall</name>
+    </creator>
+    <creator>
+      <name>Markus Demleitner</name>
+    </creator>
+    <creator>
+      <name>Tom Donaldson</name>
+    </creator>
+    <creator>
+      <name>Daniel Durand</name>
+    </creator>
+    <creator>
+      <name>Pierre Fernique</name>
+    </creator>
+    <creator>
+      <name>David Giaretta</name>
+    </creator>
+    <creator>
+      <name>Robert Hanisch</name>
+    </creator>
+    <creator>
+      <name>Tom McGlynn</name>
+    </creator>
+    <creator>
+      <name>Alex Szalay</name>
+    </creator>
+    <creator>
+      <name>Mark Taylor</name>
+    </creator>
+    <creator>
+      <name>Andreas Wicenec</name>
+    </creator>
+
+    <date role="update">2019-10-21</date>
+    <version>1.4</version>
+    <contact>
+      <name>Applications WG</name>
+      <email>apps@ivoa.net</email>
+    </contact>
+  </curation>
+  <content>
+    <subject>Virtual observatory</subject>
+    <description>
+This document describes the structures making up the VOTable standard. The main part of this document describes the adopted part of the VOTable standard; it is followed by appendices presenting extensions which have been proposed and/or discussed, but which are not part of the standard.
+    </description>
+    <referenceURL>http://www.ivoa.net/documents/VOTable</referenceURL>
+    <type>Other</type>
+  	<contentLevel>Research</contentLevel>
+  </content>
+
+  <endorsedVersion status="rec">1.4</endorsedVersion>
+
+	<schema namespace="http://www.ivoa.net/xml/VOTable/VOTable-1.4">
+		<location>http://www.ivoa.net/xml/VOTable/VOTable-1.4</location>
+		<description>VOTable is meant to serialize tabular documents in the context of Virtual Observatory applications. This schema corresponds to the VOTable document available from http://www.ivoa.net/Documents/latest/VOT.html</description>
+	</schema>
+
+</ri:Resource>


### PR DESCRIPTION
https://github.com/ivoa-std/VOTable/issues/7 No .vor record for inclusion of VOTable standard in RofR 

Creating baseline VOTable.vor file.

Note:  On the IVOA documents page, http://www.ivoa.net/xml/VOTable/1.4 does not work (however http://www.ivoa.net/xml/VOTable/1.3 forwards to 1.4 correctly).  Thus I directly referenced http://www.ivoa.net/xml/VOTable/VOTable-1.4.xsd instead of the usual shortened v1.4. What should change here?