### PR TITLE
Give position components roles in COOSYS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,12 @@ ivoatex/Makefile:
 	@echo "*** ivoatex submodule not found.  Initialising submodules."
 	@echo
 	git submodule update --init
+
+STILTS ?= stilts
+test:
+	@$(STILTS) xsdvalidate \
+		schemaloc="http://www.ivoa.net/xml/VOTable/v1.3=VOTable.xsd" \
+		coosys_example.vot
+	@$(STILTS) xsdvalidate \
+		schemaloc="http://www.ivoa.net/xml/VOTable/v1.3=VOTable.xsd" \
+		timesys_example.vot

--- a/VOTable.tex
+++ b/VOTable.tex
@@ -680,9 +680,12 @@ which the components of a position on the celestial sphere refer.  It
 has the following attributes, all of them (syntactically) optional:
 
 \begin{description}
-\item[\attr{ID}] Required if the \elem{COOSYS} element has to
-be referred to via the \attr{ref} attribute of the position components,
-which is generally the case.
+\item[\attr{ID}] Required if the \elem{COOSYS} element is to
+be referred to via the \attr{ref} attribute of the position components.
+This version of VOTable still recommends that practice, but in the
+future we intend to drop \attr{ref}-based back-references from
+components to \elem{COOSYS} in favour of \elem{FIELDref} and
+\elem{PARAMref} children (see below).
 
 \item[\attr{system}] Specifies the reference frame of the coordinates.
 The value must be taken from the IVOA \emph{refframe} vocabulary
@@ -736,12 +739,59 @@ At the time or writing, this vocabulary includes the terms
 \textsl{UNKNOWN}
 % /GENERATED
 \end{description}
-Note that the \elem{COOSYS} may be deprecated in the
+
+To facilitate comparing data at different epochs (epoch propagation),
+since VOTable version 1.5, the \elem{COOSYS} element SHOULD also be used
+to group and label coordinates and their derivatives.  This is done by
+referencing the participating \elem{FIELD}-s and/or \elem{PARAM}-s from
+the element content using \elem{FIELDref} or \elem{PARAMref} with
+\attr{utype} attributes identifying the roles of the respective items.
+
+We define role names in terms of labels within the Coords data model
+\citep{2022ivoa.specQ1004R} where possible, using an ad-hoc prefix
+\verb|votable|:
+
+\begin{description}
+\item[votable:LonLatPoint-lon] The longitude (e.g., a Right Ascension).
+\item[votable:LonLatPoint-lat] The latitude (e.g., a Declination).
+\item[votable:ProperMotion-lon] The time derivative of the longitude in
+the tangential plane (``multiplied with $\cos(\delta)$'').  We currently
+define no way to annotate raw proper motions in longitude, which are
+very rare in modern catalogues.
+\item [votable:ProperMotion-lat] The time derivative of the latitude.
+\item[votable:LonLatPoint-dist] The radial coordinate.  Both parallaxes
+(when the unit of the referenced element is an angle) and actual
+distances (with length units) are admitted.
+\item[votable:ProperMotion-rv] The radial velocity.  When the
+referenced element has no unit, it is to be interpreted as a redshift.
+\end{description}
+
+None of these roles are mandatatory, but of course even rudimentary
+epoch propagation requires a full position and both proper motions.
+More roles (e.g., for errors) may be defined in the future.  VOTable
+readers therefore MUST accept VOTables with unknown COOSYS roles, though
+they MAY issue warnings for them.
+
+Note that there can be multiple \elem{COOSYS} elements per table.  An
+example would be when both equatorial and galactic coordinates are
+given, or when there are multiple reductions of the same underlying
+data.
+
+Also note that \elem{COOSYS} may be deprecated in the
 future in favor of a more generic way of describing the conventions used
 to define the positions of the objects studied in the enclosed tables.
 
 A \elem{COOSYS} element referenced via a \attr{ref} attribute
 SHOULD appear before the element that references it.
+
+Here is an example of a \elem{COOSYS} describing a series of position
+determinations and mean proper motions, while radial information is
+missing:
+
+\begingroup\small
+\verbatiminput{coosys_example.vot}
+\endgroup
+
 
 \subsection{\elem{TIMESYS} Element}
 \label{elem:TIMESYS}
@@ -2283,9 +2333,11 @@ version 1.3 are:
 \label{diff1.4-1.5}
 
 \begin{itemize}
-\item COOSYS now has a refposition attribute analogous to TIMESYS.
-\item The frame identifiers in COOSYS are now taken from the refframe
-IVOA vocabulary.
+\item COOSYS now has a refposition attribute analogous to TIMESYS; it
+also admits FIELDref and PARAMref children now for building propagatable
+positions, and it is no longer derived from xs:string.  The latter means
+that you cannot have text content in COOSYS any more, which probably
+only was possible by accident and never had a meaning.
 \end{itemize}
 
 % NOTE: IVOA recommendations must be cited from docrepo.bib

--- a/VOTable.tex
+++ b/VOTable.tex
@@ -762,8 +762,7 @@ very rare in modern catalogues.
 \item[votable:LonLatPoint-dist] The radial coordinate.  Both parallaxes
 (when the unit of the referenced element is an angle) and actual
 distances (with length units) are admitted.
-\item[votable:ProperMotion-rv] The radial velocity.  When the
-referenced element has no unit, it is to be interpreted as a redshift.
+\item[votable:ProperMotion-rv] The radial velocity.
 \end{description}
 
 None of these roles are mandatatory, but of course even rudimentary

--- a/VOTable.xsd
+++ b/VOTable.xsd
@@ -22,7 +22,8 @@
 .Version 1.4pre1: MD: merged 1.3-Erratrum 2, added TIMESYS.
 .Version 1.4wd-a: TD: updates for initial draft of v1.4.
 .Version 1.4: TD: Change version to 1.4
-.Version 1.5pre1: MD: adding refposition attribute in COOSYS
+.Version 1.5pre1: MD: adding refposition attribute and FIELDref/PARAMref
+  in COOSYS, which no longer is derived from xs:string, either.
 .Version 1.5pre2: MD: vocabularising frame attribute in COOSYS
 -->
 <xs:schema
@@ -224,22 +225,25 @@
 
 <!-- Expresses the coordinate system we are using -->
 <xs:complexType name="CoordinateSystem">
-  <xs:simpleContent>
-    <xs:extension base="xs:string">
-      <xs:attribute name="ID" type="xs:ID" use="required"/>
-      <xs:attribute name="equinox" type="astroYear"/>
-      <xs:attribute name="epoch" type="astroYear"/>
-      <xs:attribute name="system" default="FK5">
-        <xs:annotation>
-          <xs:documentation>
-            Values for this attribute must be taken from the IVOA
-            refframe vocabulary, http://www.ivoa.net/rdf/refframe
-          </xs:documentation>
-        </xs:annotation>
-      </xs:attribute>
-      <xs:attribute name="refposition" type="xs:token"/>
-    </xs:extension>
-  </xs:simpleContent>
+  <xs:sequence minOccurs="0" maxOccurs="unbounded">
+    <xs:choice>
+      <xs:element name="FIELDref" type="FieldRef"/>
+      <xs:element name="PARAMref" type="ParamRef"/>
+    </xs:choice>
+  </xs:sequence>
+
+  <xs:attribute name="ID" type="xs:ID" use="required"/>
+  <xs:attribute name="equinox" type="astroYear"/>
+  <xs:attribute name="epoch" type="astroYear"/>
+
+  <xs:attribute name="system" default="FK5">
+    <xs:annotation>
+      <xs:documentation>
+        Values for this attribute must be taken from the IVOA
+        refframe vocabulary, http://www.ivoa.net/rdf/refframe
+      </xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
 </xs:complexType>
 
 <xs:simpleType name="Timeorigin">
@@ -615,6 +619,7 @@
        <xs:restriction base="xs:NMTOKEN">
          <xs:enumeration value="1.3"/>
          <xs:enumeration value="1.4"/>
+         <xs:enumeration value="1.5"/>
        </xs:restriction>
      </xs:simpleType>
    </xs:attribute>

--- a/coosys_example.vot
+++ b/coosys_example.vot
@@ -1,0 +1,26 @@
+<VOTABLE version="1.5" xmlns="http://www.ivoa.net/xml/VOTable/v1.3">
+  <RESOURCE>
+    <COOSYS ID="system" system="ICRS">
+      <FIELDref utype="votable:LonLatPoint-lon" ref="id-1"/>
+      <FIELDref utype="votable:LonLatPoint-lat" ref="id-2"/>
+      <PARAMref utype="votable:ProperMotion-lon" ref="id-3"/>
+      <PARAMref utype="votable:ProperMotion-lat" ref="id-4"/>
+    </COOSYS>
+    <PARAM name="pmra" ID="id-3" ucd="pos.pm;pos.eq.ra" unit="mas/yr"
+      datatype="float" value="123.45"/>
+    <PARAM name="pmdec" ID="id-4" ucd="pos.pm;pos.eq.dec" unit="mas/yr"
+      datatype="float" value="321.09"/>
+    <TABLE name="pos">
+      <FIELD name="ra" ID="id-1" datatype="double"  ucd="pos.eq.ra" unit="deg"/>
+      <FIELD name="dec" ID="id-2" datatype="double"  ucd="pos.eq.dec" unit="deg"/>
+      <DATA>
+        <TABLEDATA>
+          <TR>
+            <TD>121.2846388435</TD>
+            <TD>-33.9221492345</TD>
+          </TR>
+        </TABLEDATA>
+      </DATA>
+    </TABLE>
+  </RESOURCE>
+</VOTABLE>

--- a/timesys_example.vot
+++ b/timesys_example.vot
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.3">
+<VOTABLE version="1.5" xmlns="http://www.ivoa.net/xml/VOTable/v1.3">
   <RESOURCE>
     <COOSYS ID="system" epoch="J2015.5" system="ICRS"/>
     <TIMESYS ID="time_frame" refposition="BARYCENTER" timeorigin="2455197.5" timescale="TCB"/>
@@ -9,8 +8,10 @@
       <FIELD datatype="float" name="mag" ucd="phot.mag;em.opt.V" unit="mag"/>
       <FIELD datatype="float" name="flux_error" ucd="stat.error;phot.flux;em.opt.V"
         unit="s**-1"/>
-      <PARAM datatype="double" name="ra" ucd="pos.eq.ra" value="45.7164887146879" ref="system"/>
-      <PARAM datatype="double" name="dec" ucd="pos.eq.dec" value="1.18583048057467" ref="system"/>
+      <PARAM datatype="double" name="ra" ucd="pos.eq.ra" unit="deg"
+      	value="45.7164887146879" ref="system"/>
+      <PARAM datatype="double" name="dec" ucd="pos.eq.dec" unit="deg"
+      	value="1.18583048057467" ref="system"/>
       <DATA>
         <TABLEDATA>
           <TR>


### PR DESCRIPTION
This entails allowing FIELDref-s and PARAMref-s in COOSYS and defining role names for the various compontents.

In consequence, COOSYS now is no longer derived from string. Up to now, writing <COOSYS...>Some random text</COOSYS> was legal.  I am pretty sure that was not intended.

Also, adding regression tests for the xSYS elements.

If this is agreed upon, we should probably allow a votable:location on TIMESYS, too.