### PR TITLE
Update ivoatex and remove aap citation workaround

### DIFF
--- a/VOTable.tex
+++ b/VOTable.tex
@@ -3,8 +3,6 @@
 
 \usepackage{verbatim}
 
-\newcommand{\aap}{Astronomy and Astrophysics}
-
 \let\A=\href
 \def\Aref#1{section~\ref{#1}}
 \def\Arefs#1{section~\ref{#1}}

--- a/VOTable.tex
+++ b/VOTable.tex
@@ -822,7 +822,7 @@ has \verb|yr|, \verb|a| or \verb|Ba| as its unit and no time origin is
 given.
 When using calendar epochs written in julian or besselian years, note that
 conventionally Julian years are tied to the TDB timescale and Besselian years to
-the ET timescale \citep{2015A&A...574A..36R}.
+the ET timescale \citep{2015A+A...574A..36R}.
 
 \item[\attr{timescale}]  This is the time scale used.  Values SHOULD be
 taken from the IVOA \emph{timescale}

--- a/localrefs.bib
+++ b/localrefs.bib
@@ -29,22 +29,4 @@
    month = {dec},
    url = {http://www.ivoa.net/documents/Notes/TimeSys/}
 }
-@ARTICLE{2015A&A...574A..36R,
-       author = {{Rots}, Arnold H. and {Bunclark}, Peter S. and {Calabretta}, Mark R. and {Allen}, Steven L. and {Manchester}, Richard N. and {Thompson}, William T.},
-        title = "{Representations of time coordinates in FITS. Time and relative dimension in space}",
-      journal = {\aap},
-     keywords = {time, standards, methods: data analysis, techniques: miscellaneous, astronomical databases: miscellaneous, reference systems, Astrophysics - Instrumentation and Methods for Astrophysics},
-         year = 2015,
-        month = feb,
-       volume = {574},
-          eid = {A36},
-        pages = {A36},
-          doi = {10.1051/0004-6361/201424653},
-archivePrefix = {arXiv},
-       eprint = {1409.7583},
- primaryClass = {astro-ph.IM},
-       adsurl = {https://ui.adsabs.harvard.edu/abs/2015A&A...574A..36R},
-      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
 


### PR DESCRIPTION
With the[ ivoatex fix for ADS-defined macros](https://github.com/ivoa-std/ivoatex/issues/119), we no longer need the workaround to allow bib references to `\aas'.  This updates the ivoatex to the latest and removes that workaround.