### PR TITLE
CSS override to fix table rendering in sect 7.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ AUTHOR_EMAIL=???
 SOURCES = $(DOCNAME).tex role_diagram.pdf \
           VOTable.attr.tex VOTable.elem.tex \
           VOTable.xsd stc_example1.vot stc_example2.vot timesys_example.vot \
-          binary.pdf binary2.pdf
+          binary.pdf binary2.pdf \
+          tablefix.css
 
 # List of image files to be included in submitted package (anything that
 # can be rendered directly by common web browsers)

--- a/VOTable.tex
+++ b/VOTable.tex
@@ -1,6 +1,7 @@
 \documentclass[11pt,a4paper]{ivoa}
 \input tthdefs
 
+\customcss{tablefix.css}
 \usepackage{verbatim}
 
 \let\A=\href
@@ -2576,7 +2577,7 @@ An example of a table describing a set of spectra could look like the following:
   <FIELD name="Spectrum" ucd="meta.ref.url" datatype="float" arraysize="*"
          unit="mW/m2/nm" type="location">
     <DESCRIPTION>Spectrum absolutely calibrated</DESCRIPTION>
-    <LINK  content-role="location" 
+    <LINK  content-role="location"
         href="http://ivoa.spectr/server?obsno="/>
   </FIELD>
   <DATA><TABLEDATA>

--- a/tablefix.css
+++ b/tablefix.css
@@ -1,0 +1,4 @@
+table.tabular > * > tr > td, table.tabular > tr > td {
+        border-top: none !important;
+        border-bottom: none !important;
+      }


### PR DESCRIPTION
ivoatex usually puts rules above and below tabular-s, and that doesn't work for the pseudo tables used there.

This is a fairly lame fix that requires an extra file *and*, horror, an ``!important`` within the CSS.

If you consider this to be too abhorrent, I'd be ok with doing a fix within ivoatex, but for now I think the present horror is an artefact of an abuse of tables, and hence I'm reluctant to spend time on a good fix.