### PR TITLE
Remove reference to specific version (1.1) in appendix A

### DIFF
--- a/VOTable.tex
+++ b/VOTable.tex
@@ -2351,7 +2351,7 @@ from the refframe IVOA vocabulary.
 %\em\fg{DarkBlue}
 \section{Possible VOTable extensions}
 The definitions enclosed in this appendix
-are {\bf not} part of VOTable 1.1, but are considered as candidates
+are {\bf not} part of the VOTable standard, but are considered as candidates
 for VOTable improvements.
 %This section is a short explanation on how Astrores defines
 %the set of parameters and fields which can be qualified for a query --


### PR DESCRIPTION
Appendix A had a lingering reference to version 1.1 which was at the time the current version.  This removes that specific number.