### PR TITLE
Redefine char and unicodeChar for correct Unicode usage

### DIFF
--- a/VOTable.tex
+++ b/VOTable.tex
@@ -1155,7 +1155,7 @@ Two attributes were retained for this purpose:
 \end{itemize}
 
 When used with \attrval{datatype}{char} arrays the
-\attr{width} attribute is interpreted as (an upper bound for)
+\attr{width} attribute is interpreted as an upper bound for
 the array length in characters, i.e.\ Unicode code points.
 This value is distinct from the \attr{arraysize} attribute
 which gives the array length in UTF-8-encoded bytes.


### PR DESCRIPTION
 - char primitives are now UTF-8-encoded bytes,
 - unicodeChar primitives are now UTF-16-encoded byte pairs for BMP characters (non-BMP is excluded)
 - unicodeChar is deprecated
 - a little bit of surrounding text is rephrased to match Unicode concepts
 - there is some non-normative text explaining the implications of UTF-8 being a variable-width encoding
 - references to UCS-2 are removed