### PR TITLE
Wd1.6/mivot mango

### DIFF
--- a/VOTable.tex
+++ b/VOTable.tex
@@ -279,7 +279,16 @@ of the Data Access protocols (e.g.\ SCS, SIA, SSA, TAP),
 and hence for exchange of data and metadata
 between user layer applications and data-providing services.
 VOTable is also used as a serialization format for
-some of the IVOA Data Models.
+some of the IVOA Data Models. 
+
+This can be achieved by using metadata required by DAL standards,
+or in a more flexible way by using MIVOT (Model Instances in VOTables) annotations \citep{2023ivoa.spec.0620M}.
+MIVOT defines a syntax that maps VOTable contents to any model serialized in VO-DML \citep{2018ivoa.spec.0910L}.
+MIVOT annotations operate as a bridge between models and data, associating VOTable metadata
+with data model entities and potentially adding advanced metadata that cannot be represented in plain VOTable.
+MIVOT annotations have their own XML namespace and abide by a specific XML schema,
+which has no connection with the VOTable schema ; they are not part of the VOTable standard,
+and their use is optional.
 
 In order to represent semantically rich metadata, VOTable relies on
 the other IVOA standards UCD, Utype, VOUnits, and DALI.

--- a/VOTable.tex
+++ b/VOTable.tex
@@ -783,6 +783,10 @@ At the time of writing, this vocabulary includes the terms
 Also note that \elem{COOSYS} may be deprecated in the
 future in favor of a more generic way of describing the conventions used
 to define the positions of the objects studied in the enclosed tables.
+This generic approach could involve mapping VOTable data to the MANGO data model (REFERENCE TO MANGO),
+which provides a consistent description of complete sky positions, including position, radial velocity,
+proper motion, parallax and observation time. All of these are provided with errors,
+correlations and coordinate systems (space and time). 
 
 A \elem{COOSYS} element referenced via a \attr{ref} attribute
 SHOULD appear before the element that references it.
@@ -911,14 +915,8 @@ this attribute {\em may} however have no \elem{DATA} sub-element.
 
 For example, a \elem{RESOURCE} qualified by
 \attrval{type}{meta} can be used to transmit
-MIVOT (Model Instances in VOTables) annotations \citep{2023ivoa.spec.0620M}.
-MIVOT defines a syntax to map VOTable
-contents to any model serizalized in VO-DML \citep{2018ivoa.spec.0910L}.
-It operates as a bridge between models and data that associates VOTable
-metadata to data model entities, possibly adding advanced metadata not
-representable in plain VOTable.
-MIVOT annotations have their own XMLnamespace.  The VOTable schema allows MIVOT,
-and any elements from a foreign namespace, in a \elem{RESOURCE}.
+MIVOT annotations (see \ref{sec:voarch}).  The VOTable schema allows MIVOT annotations as 
+any elements from a foreign namespace, in a \elem{RESOURCE}.
 
 Finally, the \elem{RESOURCE} element may have a \attr{utype} attribute
 to link the element to some external data model

--- a/VOTable.tex
+++ b/VOTable.tex
@@ -783,7 +783,8 @@ At the time of writing, this vocabulary includes the terms
 Also note that \elem{COOSYS} may be deprecated in the
 future in favor of a more generic way of describing the conventions used
 to define the positions of the objects studied in the enclosed tables.
-This generic approach could involve mapping VOTable data to the MANGO data model (REFERENCE TO MANGO),
+This generic approach could involve mapping VOTable data to the MANGO 
+data model \citep{2026ivoa.spec.0529M},
 which provides a consistent description of complete sky positions, including position, radial velocity,
 proper motion, parallax and observation time. All of these are provided with errors,
 correlations and coordinate systems (space and time). 

--- a/VOTable.tex
+++ b/VOTable.tex
@@ -287,7 +287,7 @@ MIVOT defines a syntax that maps VOTable contents to any model serialized in VO-
 MIVOT annotations operate as a bridge between models and data, associating VOTable metadata
 with data model entities and potentially adding advanced metadata that cannot be represented in plain VOTable.
 MIVOT annotations have their own XML namespace and abide by a specific XML schema,
-which has no connection with the VOTable schema ; they are not part of the VOTable standard,
+which has no connection with the VOTable schema; they are not part of the VOTable standard,
 and their use is optional.
 
 In order to represent semantically rich metadata, VOTable relies on

--- a/localrefs.bib
+++ b/localrefs.bib
@@ -30,3 +30,13 @@
    url = {http://www.ivoa.net/documents/Notes/TimeSys/}
 }
 
+@MISC{2026ivoa.spec.0529M,
+       author = {{Michel}, Laurent and {Bonnarel}, Fran{\c{c}}ois and {Landais}, Gilles and {Louys}, Mireille and {Molinaro}, Marco and {Salgado}, Jesus},
+        title = "{MANGO: Metadata ANnotation for Generic Objects Version 1.0}",
+ howpublished = {IVOA Recommendation 29 May 2026},
+         year = 2026,
+        month = may,
+        pages = {529},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2026ivoa.spec.0529M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}


### PR DESCRIPTION
# MIVOT and MANGO in VOTable

- mention of the use of MIVOT annotations in section 1.4 (not normative)
- remove (reduce) MIVOT description from 3.6 (RESOURCE)
- present MANGO as a possible generic way to describe sky positions in 3.4 (COOSYS)

(see #85) 

This PR  must keep as a draft until we get a stable bib ref for MANGO (not approved by the Exec yet)

As this add-on is not normative, i don't think we have to mention it in section 9 (change log).